### PR TITLE
Daryun project renewal2

### DIFF
--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/coupon/LeisureCouponController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/coupon/LeisureCouponController.java
@@ -3,9 +3,8 @@ package com.zerobase.leisure.controller.coupon;
 import com.zerobase.leisure.domain.dto.coupon.LeisureCouponDto;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.coupon.LeisureCouponService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/leisure/coupon")
+@RequestMapping("/customer/leisure/coupon")
 @RequiredArgsConstructor
 public class LeisureCouponController {
 
@@ -27,9 +26,7 @@ public class LeisureCouponController {
     }
 
     @GetMapping
-    public @ResponseBody WebResponseData<Page<LeisureCouponDto>> getLeisureAllCoupon(@RequestParam Long customerId,
-        final Pageable pageable) {
-        Page<LeisureCouponDto> leisureCouponDtos = leisureCouponService.getLeisureAllCoupon(customerId, pageable);
-        return WebResponseData.ok(leisureCouponDtos);
+    public @ResponseBody WebResponseData<List<LeisureCouponDto>> getLeisureAllCoupon(@RequestParam Long customerId) {
+        return WebResponseData.ok(leisureCouponService.getLeisureAllCoupon(customerId));
     }
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/coupon/LeisureCouponGroupController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/coupon/LeisureCouponGroupController.java
@@ -1,7 +1,6 @@
 package com.zerobase.leisure.controller.coupon;
 
 import com.zerobase.leisure.domain.dto.coupon.LeisureCouponGroupDto;
-import com.zerobase.leisure.domain.entity.coupon.LeisureCouponGroup;
 import com.zerobase.leisure.domain.form.AddLeisureCouponGroupForm;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.coupon.LeisureCouponGroupService;
@@ -13,37 +12,35 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/leisure/couponGroup")
 @RequiredArgsConstructor
 public class LeisureCouponGroupController {
 
     private final LeisureCouponGroupService leisureCouponGroupService;
 
-    @PostMapping
+    @PostMapping("/admin/leisure/couponGroup")
     public @ResponseBody WebResponseData<String> addLeisureCouponGroup(@RequestBody AddLeisureCouponGroupForm form) {
         leisureCouponGroupService.addLeisureCouponGroup(form);
         return WebResponseData.ok("쿠폰을 등록했습니다.");
     }
 
-    @GetMapping
+    @GetMapping("/leisure/couponGroup")
     public @ResponseBody WebResponseData<Page<LeisureCouponGroupDto>> getAccommodationAllCouponGroup(final Pageable pageable) {
         Page<LeisureCouponGroupDto> leisureCouponGroupDtos = leisureCouponGroupService.getAllLeisureCouponGroup(pageable);
         return WebResponseData.ok(leisureCouponGroupDtos);
     }
 
-    @PutMapping
+    @PutMapping("/admin/leisure/couponGroup")
     public @ResponseBody WebResponseData<String> updateLeisureCouponGroup(@RequestBody AddLeisureCouponGroupForm form) {
         leisureCouponGroupService.updateLeisureCouponGroup(form);
         return WebResponseData.ok("쿠폰을 수정했습니다.");
     }
 
-    @DeleteMapping
+    @DeleteMapping("/admin/leisure/couponGroup")
     public @ResponseBody WebResponseData<String> deleteLeisureCouponGroup(@RequestParam Long leisureCouponGroupId) {
         leisureCouponGroupService.deleteLeisureCouponGroup(leisureCouponGroupId);
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/CustomerLeisureController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/CustomerLeisureController.java
@@ -1,0 +1,37 @@
+package com.zerobase.leisure.controller.leisure;
+
+
+import com.zerobase.leisure.domain.dto.leisure.CustomerLeisureDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
+import com.zerobase.leisure.domain.model.WebResponseData;
+import com.zerobase.leisure.service.leisure.CustomerLeisureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/customer/leisure")
+@RequiredArgsConstructor
+public class CustomerLeisureController {
+
+	private final CustomerLeisureService customerLeisureService;
+
+	@GetMapping
+	public @ResponseBody WebResponseData<Page<LeisureListDto>> getLeisure(@RequestParam Long sellerId, final
+		Pageable pageable) { //소비자 상품 전체 조회
+		Page<LeisureListDto> leisureDtos = customerLeisureService.getAllLeisure(sellerId, pageable);
+		return WebResponseData.ok(leisureDtos);
+	}
+
+	@GetMapping("/detail")
+	public @ResponseBody WebResponseData<CustomerLeisureDto> getDetailLeisure(@RequestParam Long leisureId) {
+		return WebResponseData.ok(
+			CustomerLeisureDto.from(customerLeisureService.getDetailLeisure(leisureId)));
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureBlackListController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureBlackListController.java
@@ -18,26 +18,25 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/leisure/blacklist")
 @RequiredArgsConstructor
 public class LeisureBlackListController {
     private final LeisureBlackListService leisureBlackListService;
 
     //블랙리스트 등록
-    @PostMapping
+    @PostMapping("/seller/leisure/blacklist")
     public @ResponseBody WebResponseData<String> addLeisureBlackList(@RequestBody AddLeisureBlackListForm form) {
         leisureBlackListService.addLeisureBlackList(form);
         return WebResponseData.ok("블랙리스트에 추가했습니다.");
     }
 
     //블랙 리스트 삭제
-    @DeleteMapping
+    @DeleteMapping("/seller/leisure/blacklist")
     public @ResponseBody WebResponseData<String> deleteLeisureBlackList(@RequestParam Long leisureBlackListId) {
         leisureBlackListService.deleteLeisureBlackList(leisureBlackListId);
         return WebResponseData.ok("성공적으로 삭제 되었습니다.");
     }
 
-    @GetMapping
+    @GetMapping("/seller/leisure/blacklist")
     public @ResponseBody WebResponseData<Page<LeisureBlackListDto>> getLeisureBlackList(@RequestParam Long leisureId,
                                                                                         final Pageable pageable) {
         Page<LeisureBlackListDto> leisureBlackListDtos = leisureBlackListService.getLeisureBlackList(leisureId, pageable);

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureReviewController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureReviewController.java
@@ -52,8 +52,8 @@ public class LeisureReviewController {
 	샐러가 답글 달기
    */
 	@PutMapping("/reply")
-	public @ResponseBody WebResponseData<String> updateReplyLeisure(@RequestParam Long leisureReviewId, @RequestBody String reply) {
-		leisureReviewService.updateReplyLeisureReview(leisureReviewId,reply);
+	public @ResponseBody WebResponseData<String> updateReplyLeisure(@RequestParam Long leisureReviewId, @RequestBody AddLeisureReviewForm form) {
+		leisureReviewService.updateReplyLeisureReview(leisureReviewId,form);
 		return WebResponseData.ok("리뷰에 답글을 남겼습니다.");
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureReviewController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureReviewController.java
@@ -20,13 +20,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
-@RequestMapping("/leisure/review")
 @RequiredArgsConstructor
 public class LeisureReviewController {
 
 	private final LeisureReviewService leisureReviewService;
 
-	@PostMapping
+	@PostMapping("/customer/leisure/review")
 	public @ResponseBody WebResponseData<String> addLeisureReview(@RequestBody AddLeisureReviewForm form) {
 		leisureReviewService.addLeisureReview(form);
 		return WebResponseData.ok("리뷰를 성공적으로 등록했습니다.");
@@ -35,14 +34,14 @@ public class LeisureReviewController {
 	/*
 	상품 조회 시 모든 리뷰 조회
 	 */
-	@GetMapping
+	@GetMapping("/customer/leisure/review")
 	public @ResponseBody WebResponseData<Page<LeisureReviewDto>> getLeisure(@RequestParam Long leisureId, final
 		Pageable pageable) {
 		Page<LeisureReviewDto> leisureReviewDtos = leisureReviewService.getAllLeisureReview(leisureId,pageable);
 		return WebResponseData.ok(leisureReviewDtos);
 	}
 
-	@PutMapping
+	@PutMapping("/customer/leisure/review")
 	public @ResponseBody WebResponseData<String> updateLeisureReview(@RequestParam Long leisureReviewId, @RequestBody AddLeisureReviewForm form) {
 		leisureReviewService.updateLeisureReview(leisureReviewId,form);
 		return WebResponseData.ok("리뷰를 수정했습니다.");
@@ -51,13 +50,13 @@ public class LeisureReviewController {
 	/*
 	샐러가 답글 달기
    */
-	@PutMapping("/reply")
+	@PutMapping("/seller/leisure/review/reply")
 	public @ResponseBody WebResponseData<String> updateReplyLeisure(@RequestParam Long leisureReviewId, @RequestBody AddLeisureReviewForm form) {
 		leisureReviewService.updateReplyLeisureReview(leisureReviewId,form);
 		return WebResponseData.ok("리뷰에 답글을 남겼습니다.");
 	}
 
-	@DeleteMapping
+	@DeleteMapping("/customer/leisure/review")
 	public @ResponseBody WebResponseData<String> deleteLeisureReview(@RequestParam Long leisureReviewId) {
 		leisureReviewService.deleteLeisureReview(leisureReviewId);
 		return WebResponseData.ok("성공적으로 삭제 되었습니다.");

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureWishController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureWishController.java
@@ -3,8 +3,9 @@ package com.zerobase.leisure.controller.leisure;
 import com.zerobase.leisure.domain.dto.leisure.LeisureWishListDto;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.leisure.LeisureWishService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,8 +34,9 @@ public class LeisureWishController {
     }
 
     @GetMapping
-    public @ResponseBody WebResponseData<List<LeisureWishListDto>> getLeisureWishList(@RequestParam Long customerId) {
-        return WebResponseData.ok(leisureWishService.getLeisureWishList(customerId));
+    public @ResponseBody WebResponseData<Page<LeisureWishListDto>> getLeisureWishList(@RequestParam Long customerId,
+        final Pageable pageable) {
+        return WebResponseData.ok(leisureWishService.getLeisureWishList(customerId, pageable));
     }
 }
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureWishController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/LeisureWishController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/leisure/wish")
+@RequestMapping("/customer/leisure/wish")
 @RequiredArgsConstructor
 public class LeisureWishController {
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
@@ -82,8 +82,8 @@ public class SellerLeisureController {
 	}
 
 	@GetMapping("/dayOff")
-	public @ResponseBody WebResponseData<List<LeisureDayOffDto>> getLeisureDayOff(@RequestParam Long leisureId) {
-		return WebResponseData.ok(LeisureDayOffDto.fromList(sellerLeisureService.getLeisureDayOff(leisureId)));
+	public @ResponseBody WebResponseData<Page<LeisureDayOffDto>> getLeisureDayOff(@RequestParam Long leisureId, final Pageable pageable) {
+		return WebResponseData.ok(sellerLeisureService.getLeisureDayOff(leisureId, pageable));
 	}
 
 	@PutMapping("/dayOff")

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
-@RequestMapping("/leisure")
+@RequestMapping("/seller/leisure")
 @RequiredArgsConstructor
 public class SellerLeisureController {
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/leisure/SellerLeisureController.java
@@ -1,21 +1,16 @@
 package com.zerobase.leisure.controller.leisure;
 
 
-import com.zerobase.common.auth.MemberDetails;
 import com.zerobase.leisure.domain.dto.leisure.LeisureDayOffDto;
 import com.zerobase.leisure.domain.dto.leisure.LeisureDto;
-import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
 import com.zerobase.leisure.domain.form.LeisureDayOffForm;
 import com.zerobase.leisure.domain.form.LeisureForm;
 import com.zerobase.leisure.domain.model.WebResponseData;
-import com.zerobase.leisure.domain.type.ErrorCode;
-import com.zerobase.leisure.exception.LeisureException;
 import com.zerobase.leisure.service.leisure.SellerLeisureService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,16 +38,16 @@ public class SellerLeisureController {
 	}
 
 	@GetMapping
-	public @ResponseBody WebResponseData<Page<LeisureDto>> getLeisure(@RequestParam Long sellerId, final
+	public @ResponseBody WebResponseData<Page<LeisureListDto>> getLeisure(@RequestParam Long sellerId, final
 		Pageable pageable) { //셀러 상품 전체 조회
-		Page<LeisureDto> leisureDtos = sellerLeisureService.getAllLeisure(sellerId, pageable);
+		Page<LeisureListDto> leisureDtos = sellerLeisureService.getAllLeisure(sellerId, pageable);
 		return WebResponseData.ok(leisureDtos);
 	}
 
 	@GetMapping("/detail")
-	public @ResponseBody WebResponseData<LeisureDto> getDetailLeisure(@RequestParam Long leisureId, @RequestParam Long sellerId) {
+	public @ResponseBody WebResponseData<LeisureDto> getDetailLeisure(@RequestParam Long leisureId) {
 		return WebResponseData.ok(
-			LeisureDto.from(sellerLeisureService.getDetailLeisure(leisureId, sellerId)));
+			LeisureDto.from(sellerLeisureService.getDetailLeisure(leisureId)));
 	}
 
 	@PutMapping

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureCartController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureCartController.java
@@ -1,6 +1,7 @@
 package com.zerobase.leisure.controller.order;
 
 import com.zerobase.leisure.domain.dto.leisure.LeisureCartDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureCartPaymentDto;
 import com.zerobase.leisure.domain.form.AddLeisureCartForm;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.order.LeisureCartService;
@@ -37,6 +38,12 @@ public class LeisureCartController {
 	public @ResponseBody WebResponseData<LeisureCartDto> getLeisureCart(@RequestParam Long customerId){
 		return WebResponseData.ok(leisureCartService.getLeisureCart(customerId));
 	}
+
+	@GetMapping("/payment")
+	public @ResponseBody WebResponseData<LeisureCartPaymentDto> getLeisureCartPayment(@RequestParam Long customerId, String customerName){
+		return WebResponseData.ok(leisureCartService.getLeisureCartPayment(customerId, customerName));
+	}
+
 
 	@PutMapping("/coupon")
 	public @ResponseBody WebResponseData<String> useCoupon(@RequestParam Long customerId, Long leisureOrderItemId, Long couponGroupId){

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureCartController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureCartController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
-@RequestMapping("/leisure/cart")
+@RequestMapping("/customer/leisure/cart")
 @RequiredArgsConstructor
 public class LeisureCartController {
 	private final LeisureCartService leisureCartService;

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
@@ -1,15 +1,11 @@
 package com.zerobase.leisure.controller.order;
 
-import com.zerobase.common.auth.MemberDetails;
 import com.zerobase.leisure.domain.dto.leisure.LeisureOrderItemDto;
 import com.zerobase.leisure.domain.model.WebResponseData;
-import com.zerobase.leisure.domain.type.ErrorCode;
-import com.zerobase.leisure.exception.LeisureException;
 import com.zerobase.leisure.service.order.LeisureOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
@@ -1,6 +1,7 @@
 package com.zerobase.leisure.controller.order;
 
 import com.zerobase.leisure.domain.dto.leisure.LeisureOrderItemDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureOrderListDto;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.order.LeisureOrderService;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +30,20 @@ public class LeisureOrderController {
 	}
 
 	@GetMapping
-	public @ResponseBody WebResponseData<Page<LeisureOrderItemDto>> getLeisureOrder(@RequestParam Long customerId,
+	public @ResponseBody WebResponseData<Page<LeisureOrderListDto>> getLeisureOrder(@RequestParam Long customerId,
 		final Pageable pageable) {
 //		if (memberDetails==null) {
 //			throw new LeisureException(ErrorCode.NOT_AUTHORIZED);
 //		}
 		return WebResponseData.ok(leisureOrderService.getLeisureOrder(customerId,pageable));
+	}
+
+	@GetMapping("/detail")
+	public @ResponseBody WebResponseData<Page<LeisureOrderItemDto>> getLeisureOrderDetail(@RequestParam Long orderId,
+		final Pageable pageable) {
+//		if (memberDetails==null) {
+//			throw new LeisureException(ErrorCode.NOT_AUTHORIZED);
+//		}
+		return WebResponseData.ok(leisureOrderService.getLeisureOrderDetail(orderId,pageable));
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
-@RequestMapping("/leisure/order")
+@RequestMapping("/customer/leisure/order")
 @RequiredArgsConstructor
 public class LeisureOrderController {
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/payment/LeisurePaymentController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/payment/LeisurePaymentController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/leisure/payment")
+@RequestMapping("/customer/leisure/payment")
 @RequiredArgsConstructor
 public class LeisurePaymentController {
     //카카오API는 결제 준비 > 결제 요청 - 결제 준비에서 리턴된 URL로 카카오페이와 연결 > 카카오페이(폰)에서 결제 후 결제 승인 이 순서로 진행됩니다.

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
@@ -15,11 +15,14 @@ public class LeisureCouponDto {
 	private Long couponId;
 	private Long couponGroupId;
 
+	private Integer salePrice;
+
 	private String endTime;
 
-	public static LeisureCouponDto from(LeisureCoupon leisureCoupon) {
+	public static LeisureCouponDto from(LeisureCoupon leisureCoupon, Integer salePrice) {
 		return LeisureCouponDto.builder()
 			.couponId(leisureCoupon.getId())
+			.salePrice(salePrice)
 			.couponGroupId(leisureCoupon.getCouponGroupId())
 			.endTime(leisureCoupon.getEndTime().toString())
 			.build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.domain.dto.coupon;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.coupon.LeisureCoupon;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -15,22 +16,15 @@ import lombok.NoArgsConstructor;
 public class LeisureCouponDto {
 
 	private Long id;
-	private Long customerId;
 	private Long couponGroupId;
 
-	private boolean usedYN;
-
-	private LocalDateTime usedTime;
-
+	@JsonFormat
 	private LocalDate endTime;
 
 	public static LeisureCouponDto from(LeisureCoupon leisureCoupon) {
 		return LeisureCouponDto.builder()
 			.id(leisureCoupon.getId())
-			.customerId(leisureCoupon.getCustomerId())
 			.couponGroupId(leisureCoupon.getCouponGroupId())
-			.usedYN(leisureCoupon.isUsedYN())
-			.usedTime(leisureCoupon.getUsedTime())
 			.endTime(leisureCoupon.getEndTime())
 			.build();
 	}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
@@ -1,9 +1,6 @@
 package com.zerobase.leisure.domain.dto.coupon;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.coupon.LeisureCoupon;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,14 +12,14 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LeisureCouponDto {
 
-	private Long id;
+	private Long couponId;
 	private Long couponGroupId;
 
 	private String endTime;
 
 	public static LeisureCouponDto from(LeisureCoupon leisureCoupon) {
 		return LeisureCouponDto.builder()
-			.id(leisureCoupon.getId())
+			.couponId(leisureCoupon.getId())
 			.couponGroupId(leisureCoupon.getCouponGroupId())
 			.endTime(leisureCoupon.getEndTime().toString())
 			.build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponDto.java
@@ -18,14 +18,13 @@ public class LeisureCouponDto {
 	private Long id;
 	private Long couponGroupId;
 
-	@JsonFormat
-	private LocalDate endTime;
+	private String endTime;
 
 	public static LeisureCouponDto from(LeisureCoupon leisureCoupon) {
 		return LeisureCouponDto.builder()
 			.id(leisureCoupon.getId())
 			.couponGroupId(leisureCoupon.getCouponGroupId())
-			.endTime(leisureCoupon.getEndTime())
+			.endTime(leisureCoupon.getEndTime().toString())
 			.build();
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.domain.dto.coupon;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.coupon.LeisureCouponGroup;
 import com.zerobase.leisure.domain.type.CouponTarget;
 import java.time.LocalDate;
@@ -19,7 +20,7 @@ public class LeisureCouponGroupDto {
     private Integer salePrice;
     private CouponTarget couponTarget;
     private Integer issuedCount;
-
+    @JsonFormat
     private LocalDate endTime;
 
     public static LeisureCouponGroupDto from(LeisureCouponGroup leisureCouponGroup) {

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureCouponGroupDto {
-    private Long id;
+    private Long couponGroupId;
 
     private Integer salePrice;
     private CouponTarget couponTarget;
@@ -21,7 +21,7 @@ public class LeisureCouponGroupDto {
 
     public static LeisureCouponGroupDto from(LeisureCouponGroup leisureCouponGroup) {
         return LeisureCouponGroupDto.builder()
-            .id(leisureCouponGroup.getId())
+            .couponGroupId(leisureCouponGroup.getId())
             .salePrice(leisureCouponGroup.getSalePrice())
             .couponTarget(leisureCouponGroup.getCouponTarget())
             .issuedCount(leisureCouponGroup.getIssuedCount())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/coupon/LeisureCouponGroupDto.java
@@ -1,10 +1,7 @@
 package com.zerobase.leisure.domain.dto.coupon;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.coupon.LeisureCouponGroup;
 import com.zerobase.leisure.domain.type.CouponTarget;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +17,7 @@ public class LeisureCouponGroupDto {
     private Integer salePrice;
     private CouponTarget couponTarget;
     private Integer issuedCount;
-    @JsonFormat
-    private LocalDate endTime;
+    private String endTime;
 
     public static LeisureCouponGroupDto from(LeisureCouponGroup leisureCouponGroup) {
         return LeisureCouponGroupDto.builder()
@@ -29,7 +25,7 @@ public class LeisureCouponGroupDto {
             .salePrice(leisureCouponGroup.getSalePrice())
             .couponTarget(leisureCouponGroup.getCouponTarget())
             .issuedCount(leisureCouponGroup.getIssuedCount())
-            .endTime(leisureCouponGroup.getEndTime())
+            .endTime(leisureCouponGroup.getEndTime().toString())
             .build();
     }
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/CustomerLeisureDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/CustomerLeisureDto.java
@@ -1,0 +1,53 @@
+package com.zerobase.leisure.domain.dto.leisure;
+
+import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CustomerLeisureDto {
+	private Long id;
+	private Long sellerId;
+
+	private String name;
+	private String addr;
+	private Integer price;
+	private String description;
+
+	private String pictureUrl;
+
+	private Integer minPerson;
+	private Integer maxPerson;
+
+	private double lat;
+	private double lon;
+
+	public static CustomerLeisureDto from(Leisure leisure) {
+		return CustomerLeisureDto.builder()
+			.id(leisure.getId())
+			.sellerId(leisure.getSellerId())
+			.name(leisure.getLeisureName())
+			.addr(leisure.getAddr())
+			.pictureUrl(leisure.getPictureUrl())
+			.price(leisure.getPrice())
+			.maxPerson(leisure.getMaxPerson())
+			.minPerson(leisure.getMinPerson())
+			.description(leisure.getDescription())
+			.lat(leisure.getLat())
+			.lon(leisure.getLon())
+			.build();
+	}
+
+	public static List<CustomerLeisureDto> fromList(List<Leisure> leisureList) {
+		return leisureList.stream()
+			.map(CustomerLeisureDto::from)
+			.collect(Collectors.toList());
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureBlackListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureBlackListDto.java
@@ -14,16 +14,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class LeisureBlackListDto {
 
-    private Long leisureBlackListId;
-    private Long leisureId;
+    private Long blackListId;
+    private Long id;
 
     private Long customerId;
     private String description;
 
     public static LeisureBlackListDto from(LeisureBlackList leisureBlackList) {
         return LeisureBlackListDto.builder()
-            .leisureBlackListId(leisureBlackList.getId())
-            .leisureId(leisureBlackList.getLeisureId())
+            .blackListId(leisureBlackList.getId())
+            .id(leisureBlackList.getLeisureId())
             .customerId(leisureBlackList.getCustomerId())
             .description(leisureBlackList.getDescription())
             .build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class LeisureCartDto {
 	private Long cartId;
 
-	private List<LeisureOrderItemDto> leisureOrderItemList;
+	private List<LeisureCartItemDto> cartItemList;
 
 	private Integer totalPrice;
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
@@ -13,39 +13,29 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LeisureOrderItemDto {
+public class LeisureCartItemDto {
 	private Long leisureOrderItemId;
-	private Long sellerId;
-
-	private String reservationId;
-
-	private Long couponId;
-	private Integer salePrice;
 
 	private String leisureName;
-	private String addr;
 	private Integer price;
 
 	private String pictureUrl;
 
 	private Integer persons;
 
-	private String startAt;
-	private String endAt;
+	@JsonFormat
+	private LocalDateTime startAt;
+	@JsonFormat
+	private LocalDateTime endAt;
 
-	public static LeisureOrderItemDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
-		return LeisureOrderItemDto.builder()
+	public static LeisureCartItemDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
+		return LeisureCartItemDto.builder()
 			.leisureOrderItemId(leisureOrderItem.getId())
-			.reservationId(leisureOrderItem.getReservationId())
-			.sellerId(leisure.getSellerId())
-			.couponId(leisureOrderItem.getCouponId())
-			.salePrice(leisureOrderItem.getSalePrice())
 			.leisureName(leisure.getLeisureName())
-			.addr(leisure.getAddr())
-			.price(leisureOrderItem.getPrice())
+			.price(leisure.getPrice())
 			.persons(leisureOrderItem.getPersons())
-			.startAt(leisureOrderItem.getStartAt().toString())
-			.endAt(leisureOrderItem.getEndAt().toString())
+			.startAt(leisureOrderItem.getStartAt())
+			.endAt(leisureOrderItem.getEndAt())
 			.build();
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
@@ -29,6 +29,7 @@ public class LeisureCartItemDto {
 			.orderItemId(leisureOrderItem.getId())
 			.name(leisure.getLeisureName())
 			.price(leisure.getPrice())
+			.pictureUrl(leisure.getPictureUrl())
 			.persons(leisureOrderItem.getPersons())
 			.startAt(leisureOrderItem.getStartAt().toString())
 			.endAt(leisureOrderItem.getEndAt().toString())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartItemDto.java
@@ -1,9 +1,7 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
 import com.zerobase.leisure.domain.entity.order.LeisureOrderItem;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,28 +12,26 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureCartItemDto {
-	private Long leisureOrderItemId;
+	private Long orderItemId;
 
-	private String leisureName;
+	private String name;
 	private Integer price;
 
 	private String pictureUrl;
 
 	private Integer persons;
 
-	@JsonFormat
-	private LocalDateTime startAt;
-	@JsonFormat
-	private LocalDateTime endAt;
+	private String startAt;
+	private String endAt;
 
 	public static LeisureCartItemDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
 		return LeisureCartItemDto.builder()
-			.leisureOrderItemId(leisureOrderItem.getId())
-			.leisureName(leisure.getLeisureName())
+			.orderItemId(leisureOrderItem.getId())
+			.name(leisure.getLeisureName())
 			.price(leisure.getPrice())
 			.persons(leisureOrderItem.getPersons())
-			.startAt(leisureOrderItem.getStartAt())
-			.endAt(leisureOrderItem.getEndAt())
+			.startAt(leisureOrderItem.getStartAt().toString())
+			.endAt(leisureOrderItem.getEndAt().toString())
 			.build();
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class LeisureCartPaymentDto {
 	private Long cartId;
 
-	private String userName;
+	private String customerName;
 
 	private List<LeisureOrderItemDto> orderItemList;
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
@@ -1,0 +1,21 @@
+package com.zerobase.leisure.domain.dto.leisure;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeisureCartPaymentDto {
+	private Long cartId;
+
+	private String userName;
+
+	private List<LeisureOrderItemDto> leisureOrderItemList;
+
+	private Integer totalPrice;
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartPaymentDto.java
@@ -15,7 +15,7 @@ public class LeisureCartPaymentDto {
 
 	private String userName;
 
-	private List<LeisureOrderItemDto> leisureOrderItemList;
+	private List<LeisureOrderItemDto> orderItemList;
 
 	private Integer totalPrice;
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
@@ -1,8 +1,6 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -15,8 +13,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureDayOffDto {
+	private Long dayOffId;
 	private Long id;
-	private Long leisureId;
 
 	private String year;
 	private String startDate;
@@ -24,8 +22,8 @@ public class LeisureDayOffDto {
 
 	public static LeisureDayOffDto from(LeisureDayOff leisureDayOff) {
 		return LeisureDayOffDto.builder()
-			.id(leisureDayOff.getId())
-			.leisureId(leisureDayOff.getLeisureId())
+			.dayOffId(leisureDayOff.getId())
+			.id(leisureDayOff.getLeisureId())
 			.year(leisureDayOff.getYear())
 			.startDate(leisureDayOff.getStartDate().toString())
 			.endDate(leisureDayOff.getEndDate().toString())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
@@ -25,8 +25,8 @@ public class LeisureDayOffDto {
 			.dayOffId(leisureDayOff.getId())
 			.id(leisureDayOff.getLeisureId())
 			.year(leisureDayOff.getYear())
-			.startDate(leisureDayOff.getStartDate().toString())
-			.endDate(leisureDayOff.getEndDate().toString())
+			.startDate(leisureDayOff.getStartAt().toString())
+			.endDate(leisureDayOff.getEndAt().toString())
 			.build();
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
 import java.time.LocalDate;
 import java.util.List;
@@ -18,7 +19,9 @@ public class LeisureDayOffDto {
 	private Long leisureId;
 
 	private String year;
+	@JsonFormat
 	private LocalDate startDate;
+	@JsonFormat
 	private LocalDate endDate;
 
 	public static LeisureDayOffDto from(LeisureDayOff leisureDayOff) {

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDayOffDto.java
@@ -19,18 +19,16 @@ public class LeisureDayOffDto {
 	private Long leisureId;
 
 	private String year;
-	@JsonFormat
-	private LocalDate startDate;
-	@JsonFormat
-	private LocalDate endDate;
+	private String startDate;
+	private String endDate;
 
 	public static LeisureDayOffDto from(LeisureDayOff leisureDayOff) {
 		return LeisureDayOffDto.builder()
 			.id(leisureDayOff.getId())
 			.leisureId(leisureDayOff.getLeisureId())
 			.year(leisureDayOff.getYear())
-			.startDate(leisureDayOff.getStartDate())
-			.endDate(leisureDayOff.getEndDate())
+			.startDate(leisureDayOff.getStartDate().toString())
+			.endDate(leisureDayOff.getEndDate().toString())
 			.build();
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureDto.java
@@ -16,7 +16,7 @@ public class LeisureDto {
 	private Long id;
 	private Long sellerId;
 
-	private String leisureName;
+	private String name;
 	private String addr;
 	private Integer price;
 	private String description;
@@ -33,7 +33,7 @@ public class LeisureDto {
 		return LeisureDto.builder()
 			.id(leisure.getId())
 			.sellerId(leisure.getSellerId())
-			.leisureName(leisure.getLeisureName())
+			.name(leisure.getLeisureName())
 			.addr(leisure.getAddr())
 			.pictureUrl(leisure.getPictureUrl())
 			.price(leisure.getPrice())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureListDto.java
@@ -1,0 +1,53 @@
+package com.zerobase.leisure.domain.dto.leisure;
+
+import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeisureListDto {
+	private Long id;
+	private Long sellerId;
+
+	private String leisureName;
+	private String addr;
+	private Integer price;
+	private String description;
+
+	private String pictureUrl;
+
+	private Integer minPerson;
+	private Integer maxPerson;
+
+	private double lat;
+	private double lon;
+
+	public static LeisureListDto from(Leisure leisure) {
+		return LeisureListDto.builder()
+			.id(leisure.getId())
+			.sellerId(leisure.getSellerId())
+			.leisureName(leisure.getLeisureName())
+			.addr(leisure.getAddr())
+			.pictureUrl(leisure.getPictureUrl())
+			.price(leisure.getPrice())
+			.maxPerson(leisure.getMaxPerson())
+			.minPerson(leisure.getMinPerson())
+			.description(leisure.getDescription())
+			.lat(leisure.getLat())
+			.lon(leisure.getLon())
+			.build();
+	}
+
+	public static List<LeisureListDto> fromList(List<Leisure> leisureList) {
+		return leisureList.stream()
+			.map(LeisureListDto::from)
+			.collect(Collectors.toList());
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureListDto.java
@@ -16,32 +16,20 @@ public class LeisureListDto {
 	private Long id;
 	private Long sellerId;
 
-	private String leisureName;
+	private String name;
 	private String addr;
 	private Integer price;
-	private String description;
 
 	private String pictureUrl;
-
-	private Integer minPerson;
-	private Integer maxPerson;
-
-	private double lat;
-	private double lon;
 
 	public static LeisureListDto from(Leisure leisure) {
 		return LeisureListDto.builder()
 			.id(leisure.getId())
 			.sellerId(leisure.getSellerId())
-			.leisureName(leisure.getLeisureName())
+			.name(leisure.getLeisureName())
 			.addr(leisure.getAddr())
 			.pictureUrl(leisure.getPictureUrl())
 			.price(leisure.getPrice())
-			.maxPerson(leisure.getMaxPerson())
-			.minPerson(leisure.getMinPerson())
-			.description(leisure.getDescription())
-			.lat(leisure.getLat())
-			.lon(leisure.getLon())
 			.build();
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
 import com.zerobase.leisure.domain.entity.order.LeisureOrderItem;
 import java.time.LocalDateTime;
@@ -29,7 +30,9 @@ public class LeisureOrderItemDto {
 
 	private Integer persons;
 
+	@JsonFormat
 	private LocalDateTime startAt;
+	@JsonFormat
 	private LocalDateTime endAt;
 
 	public static LeisureOrderItemDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemDto.java
@@ -34,6 +34,7 @@ public class LeisureOrderItemDto {
 			.sellerId(leisure.getSellerId())
 			.couponId(leisureOrderItem.getCouponId())
 			.salePrice(leisureOrderItem.getSalePrice())
+			.pictureUrl(leisure.getPictureUrl())
 			.name(leisure.getLeisureName())
 			.price(leisureOrderItem.getPrice())
 			.persons(leisureOrderItem.getPersons())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderListDto.java
@@ -1,6 +1,7 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import com.zerobase.leisure.domain.entity.order.LeisureOrder;
 import com.zerobase.leisure.domain.entity.order.LeisureOrderItem;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +28,15 @@ public class LeisureOrderListDto {
 	private String startAt;
 	private String endAt;
 
-	public static LeisureOrderListDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
+	public static LeisureOrderListDto from(LeisureOrder leisureOrder, LeisureOrderItem leisureOrderItem, Leisure leisure
+		,int cnt) {
 		return LeisureOrderListDto.builder()
+			.orderId(leisureOrder.getId())
+			.reservationId(leisureOrder.getReservationId())
 			.name(leisure.getLeisureName())
+			.pictureUrl(leisure.getPictureUrl())
 			.persons(leisureOrderItem.getPersons())
+			.orderCount(cnt)
 			.startAt(leisureOrderItem.getStartAt().toString())
 			.endAt(leisureOrderItem.getEndAt().toString())
 			.build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderListDto.java
@@ -11,31 +11,25 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LeisureOrderItemDto {
-	private Long orderItemId;
-	private Long sellerId;
+public class LeisureOrderListDto {
+	private Long orderId;
 
-	private Long couponId;
-	private Integer salePrice;
+	private String reservationId;
 
 	private String name;
-	private Integer price;
 
 	private String pictureUrl;
 
 	private Integer persons;
 
+	private Integer orderCount; //주문 개수
+
 	private String startAt;
 	private String endAt;
 
-	public static LeisureOrderItemDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
-		return LeisureOrderItemDto.builder()
-			.orderItemId(leisureOrderItem.getId())
-			.sellerId(leisure.getSellerId())
-			.couponId(leisureOrderItem.getCouponId())
-			.salePrice(leisureOrderItem.getSalePrice())
+	public static LeisureOrderListDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
+		return LeisureOrderListDto.builder()
 			.name(leisure.getLeisureName())
-			.price(leisureOrderItem.getPrice())
 			.persons(leisureOrderItem.getPersons())
 			.startAt(leisureOrderItem.getStartAt().toString())
 			.endAt(leisureOrderItem.getEndAt().toString())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureReviewDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureReviewDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureReviewDto {
-	private Long leisureReviewId;
+	private Long reviewId;
 
 	private Long customerId;
 	private Long sellerId;
@@ -26,7 +26,7 @@ public class LeisureReviewDto {
 
 	public static LeisureReviewDto from(LeisureReview leisureReview) {
 		return LeisureReviewDto.builder()
-			.leisureReviewId(leisureReview.getId())
+			.reviewId(leisureReview.getId())
 			.sellerId(leisureReview.getSellerId())
 			.customerId(leisureReview.getCustomerId())
 			.leisureId(leisureReview.getLeisureId())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureWishListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureWishListDto.java
@@ -12,21 +12,21 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureWishListDto {
-	private Long leisureWishListId;
-	private Long leisureId;
+	private Long wishListId;
+	private Long id;
 
 	private Long memberId;
-	private String leisureName;
+	private String name;
 	private String addr;
 	private Integer price;
 	private String pictureUrl;
 
 	public static LeisureWishListDto from(LeisureWishList LeisureWishList, Leisure leisure) {
 		return LeisureWishListDto.builder()
-			.leisureWishListId(LeisureWishList.getId())
-			.leisureId(leisure.getId())
+			.wishListId(LeisureWishList.getId())
+			.id(leisure.getId())
 			.memberId(LeisureWishList.getMemberId())
-			.leisureName(leisure.getLeisureName())
+			.name(leisure.getLeisureName())
 			.addr(leisure.getAddr())
 			.price(leisure.getPrice())
 			.pictureUrl(leisure.getPictureUrl())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/payment/LeisurePaymentDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/payment/LeisurePaymentDto.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.domain.dto.payment;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.zerobase.leisure.domain.entity.order.LeisurePayment;
 import com.zerobase.leisure.domain.type.PaymentStatus;
 import java.time.LocalDateTime;
@@ -26,6 +27,7 @@ public class LeisurePaymentDto {
 
     private PaymentStatus status;
 
+    @JsonFormat
     private LocalDateTime canceledAt;
     private String nextRedirectURL;
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/payment/LeisurePaymentDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/payment/LeisurePaymentDto.java
@@ -14,11 +14,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisurePaymentDto {
-    private Long leisurePaymentId;
+    private Long paymentId;
     private Long customerId;
-    private Long leisureOrderItemId; // 주문 상품 아이디
+    private Long orderItemId; // 주문 상품 아이디
 
-    private Long leisureId;
+    private Long id;
 
     private Integer price;
 
@@ -27,23 +27,22 @@ public class LeisurePaymentDto {
 
     private PaymentStatus status;
 
-    @JsonFormat
-    private LocalDateTime canceledAt;
+    private String canceledAt;
     private String nextRedirectURL;
 
     private String approveURL;
 
     public static LeisurePaymentDto from(LeisurePayment leisurePayment, String nextRedirectURL, String approveURL) {
         return LeisurePaymentDto.builder()
-            .leisurePaymentId(leisurePayment.getId())
+            .paymentId(leisurePayment.getId())
             .customerId(leisurePayment.getCustomerId())
-            .leisureOrderItemId(leisurePayment.getLeisureOrderItemId())
-            .leisureId(leisurePayment.getLeisureId())
+            .orderItemId(leisurePayment.getLeisureOrderItemId())
+            .id(leisurePayment.getLeisureId())
             .price(leisurePayment.getPrice())
             .tid(leisurePayment.getTid())
             .paymentToken(leisurePayment.getPaymentToken())
             .status(leisurePayment.getStatus())
-            .canceledAt(leisurePayment.getCanceledAt())
+            .canceledAt(leisurePayment.getCanceledAt().toString())
             .nextRedirectURL(nextRedirectURL)
             .approveURL(approveURL)
             .build();
@@ -51,15 +50,15 @@ public class LeisurePaymentDto {
 
     public static LeisurePaymentDto from(LeisurePayment leisurePayment) {
         return LeisurePaymentDto.builder()
-            .leisurePaymentId(leisurePayment.getId())
+            .paymentId(leisurePayment.getId())
             .customerId(leisurePayment.getCustomerId())
-            .leisureOrderItemId(leisurePayment.getLeisureOrderItemId())
-            .leisureId(leisurePayment.getLeisureId())
+            .orderItemId(leisurePayment.getLeisureOrderItemId())
+            .id(leisurePayment.getLeisureId())
             .price(leisurePayment.getPrice())
             .tid(leisurePayment.getTid())
             .paymentToken(leisurePayment.getPaymentToken())
             .status(leisurePayment.getStatus())
-            .canceledAt(leisurePayment.getCanceledAt())
+            .canceledAt(leisurePayment.getCanceledAt().toString())
             .build();
     }
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/LeisureReservationDay.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/LeisureReservationDay.java
@@ -1,7 +1,7 @@
 package com.zerobase.leisure.domain.entity.leisure;
 
 import com.zerobase.leisure.domain.entity.common.BaseEntity;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -20,13 +20,13 @@ import org.hibernate.envers.AuditOverride;
 @Builder
 @Setter
 @Getter
-public class LeisureDayOff extends BaseEntity{
+public class LeisureReservationDay extends BaseEntity{
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 	private Long leisureId;
 
 	private String year;
-	private LocalDate startAt;
-	private LocalDate endAt;
+	private LocalDateTime startAt;
+	private LocalDateTime endAt;
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrder.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrder.java
@@ -30,6 +30,8 @@ public class LeisureOrder extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	private String reservationId;
+
 	private Long customerId;
 
 	private Long leisurePaymentId;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrderItem.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrderItem.java
@@ -31,8 +31,6 @@ public class LeisureOrderItem extends BaseEntity {
 	private Long sellerId;
 	private Long leisureId;
 
-	private String reservationId;
-
 	private Long leisureOrderId;
 
 	private Long couponId;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCouponGroupForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCouponGroupForm.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class AddLeisureCouponGroupForm {
-    private Long LeisureCouponGroupId;
+    private Long leisureCouponGroupId;
 
     private Integer salePrice;
     private CouponTarget couponTarget;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/model/WebResponseData.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/model/WebResponseData.java
@@ -12,14 +12,15 @@ import lombok.ToString;
 @ToString
 public class WebResponseData<T> {
 	private ErrorCode code;
+	private String type;
 	private String description;
 	private T data;
 
 	public static <T> WebResponseData<T> ok(T data) {
-		return new WebResponseData<T>(ErrorCode.SUCCESS_CODE, ErrorCode.SUCCESS_CODE.getDescription(), data);
+		return new WebResponseData<T>(ErrorCode.SUCCESS_CODE,"leisure", ErrorCode.SUCCESS_CODE.getDescription(), data);
 	}
 
 	public static <T> WebResponseData<T> error(ErrorCode errorCode) {
-		return new WebResponseData<T>(errorCode, errorCode.getDescription(), null);
+		return new WebResponseData<T>(errorCode,"leisure", errorCode.getDescription(), null);
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/coupon/LeisureCouponRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/coupon/LeisureCouponRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.leisure.domain.repository.coupon;
 
 import com.zerobase.leisure.domain.entity.coupon.LeisureCoupon;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,5 +15,5 @@ public interface LeisureCouponRepository extends JpaRepository<LeisureCoupon, Lo
 
 	Long countByCouponGroupId(Long couponGroupId);
 
-	Page<LeisureCoupon> findAllByCustomerIdAndUsedYNFalse(Long customerId, Pageable limit);
+	Optional<List<LeisureCoupon>> findByCustomerIdAndUsedYN(Long customerId, boolean usingYn);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureDayOffRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureDayOffRepository.java
@@ -1,13 +1,14 @@
 package com.zerobase.leisure.domain.repository.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LeisureDayOffRepository extends JpaRepository<LeisureDayOff, Long> {
 	Optional<LeisureDayOff> findByLeisureId(Long LeisureId);
-	Optional<List<LeisureDayOff>> findAllByLeisureId(Long leisureId);
+	Optional<Page<LeisureDayOff>> findAllByLeisureId(Long leisureId, Pageable limit);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LeisureReservationDayRepository extends JpaRepository<LeisureReservationDay, Long> {
-	Optional<LeisureReservationDay> findByStartAtBetween(LocalDateTime startAt, LocalDateTime endAt);
-	Optional<LeisureReservationDay> findByEndAtBetween(LocalDateTime startAt, LocalDateTime endAt);
+	Optional<LeisureReservationDay> findByLeisureIdAndStartAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
+	Optional<LeisureReservationDay> findByLeisureIdAndEndAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
@@ -1,0 +1,13 @@
+package com.zerobase.leisure.domain.repository.leisure;
+
+import com.zerobase.leisure.domain.entity.leisure.LeisureReservationDay;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeisureReservationDayRepository extends JpaRepository<LeisureReservationDay, Long> {
+	Optional<LeisureReservationDay> findByStartAtBetween(LocalDateTime startAt, LocalDateTime endAt);
+	Optional<LeisureReservationDay> findByEndAtBetween(LocalDateTime startAt, LocalDateTime endAt);
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureWishListRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureWishListRepository.java
@@ -1,8 +1,9 @@
 package com.zerobase.leisure.domain.repository.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.LeisureWishList;
-import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +14,5 @@ public interface LeisureWishListRepository extends JpaRepository<LeisureWishList
 
 	void deleteByMemberIdAndLeisureId(Long memberId, Long leisureId);
 
-	Optional<List<LeisureWishList>> findAllByMemberId(Long memberId);
+	Optional<Page<LeisureWishList>> findAllByMemberId(Long memberId, Pageable limit);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderItemRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderItemRepository.java
@@ -15,7 +15,10 @@ public interface LeisureOrderItemRepository extends JpaRepository<LeisureOrderIt
 	Optional<LeisureOrderItem> findByLeisureCart_CustomerIdAndLeisureId(Long customerId, Long leisureId);
 	void deleteByIdAndLeisureCart_CustomerId(Long id, Long LeisureCartId);
 
+	Optional<List<LeisureOrderItem>> findByLeisureOrderId(Long orderId);
+
 	Page<LeisureOrderItem> findAllByLeisureOrderIdIn(List<Long> ids, Pageable limit);
+	Page<LeisureOrderItem> findAllByLeisureOrderId(Long orderId, Pageable limit);
 
 	Optional<LeisureOrderItem> findByCouponId(Long couponId);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderRepository.java
@@ -3,6 +3,8 @@ package com.zerobase.leisure.domain.repository.order;
 import com.zerobase.leisure.domain.entity.order.LeisureOrder;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface LeisureOrderRepository extends JpaRepository<LeisureOrder, Long> {
 	Optional<LeisureOrder> findByCustomerIdAndLeisurePaymentId(Long customerId, Long leisurePaymentId);
 
-	List<LeisureOrder> findByCustomerId(Long customerId);
+	Page<LeisureOrder> findByCustomerId(Long customerId, Pageable limit);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/type/ErrorCode.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/type/ErrorCode.java
@@ -35,7 +35,8 @@ public enum ErrorCode {
 	NOT_PAYMENT_ORDER("결제된 주문이 아닙니다."),
 	NOT_MY_COUPON("발급 받은 쿠폰이 아닙니다."),
 	NOT_FOUND_COUPON("쿠폰 정보를 찾을 수 없습니다."),
-	ALREADY_USED_COUPON("이미 사용한 쿠폰입니다.")
+	ALREADY_USED_COUPON("이미 사용한 쿠폰입니다."),
+	ALREADY_RESERVATION_DAY("이미 예약된 시간입니다.")
 	;
 
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/coupon/LeisureCouponGroupService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/coupon/LeisureCouponGroupService.java
@@ -30,7 +30,6 @@ public class LeisureCouponGroupService {
     public LeisureCouponGroup updateLeisureCouponGroup(AddLeisureCouponGroupForm form) {
         LeisureCouponGroup leisureCouponGroup = findCouponGroup(form.getLeisureCouponGroupId());
 
-        leisureCouponGroup.setId(form.getLeisureCouponGroupId());
         leisureCouponGroup.setCouponTarget(form.getCouponTarget());
         leisureCouponGroup.setSalePrice(form.getSalePrice());
         leisureCouponGroup.setIssuedCount(form.getIssuedCount());

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/CustomerLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/CustomerLeisureService.java
@@ -1,0 +1,42 @@
+package com.zerobase.leisure.service.leisure;
+
+import com.zerobase.leisure.domain.dto.leisure.LeisureDayOffDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
+import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
+import com.zerobase.leisure.domain.form.LeisureDayOffForm;
+import com.zerobase.leisure.domain.form.LeisureForm;
+import com.zerobase.leisure.domain.repository.leisure.LeisureDayOffRepository;
+import com.zerobase.leisure.domain.repository.leisure.LeisureRepository;
+import com.zerobase.leisure.domain.type.ErrorCode;
+import com.zerobase.leisure.exception.LeisureException;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerLeisureService {
+	private final LeisureRepository leisureRepository;
+
+	public Page<LeisureListDto> getAllLeisure(Long sellerId, Pageable pageable) {
+		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15, Sort.by("id"));
+
+		Page<Leisure> leisurePage = leisureRepository.findAllBySellerId(sellerId, limit);
+
+		List<LeisureListDto> leisureDtos = LeisureListDto.fromList(leisurePage.toList());
+
+		return new PageImpl<>(leisureDtos, limit, leisurePage.getTotalElements());
+	}
+
+	public Leisure getDetailLeisure(Long leisureId) {
+		return leisureRepository.findById(leisureId)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureReviewService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureReviewService.java
@@ -50,11 +50,11 @@ public class LeisureReviewService {
 		return leisureReviewRepository.save(leisureReview);
 	}
 
-	public LeisureReview updateReplyLeisureReview(Long reviewId, String reply) {
+	public LeisureReview updateReplyLeisureReview(Long reviewId, AddLeisureReviewForm form) {
 		LeisureReview leisureReview = leisureReviewRepository.findById(reviewId)
 			.orElseThrow(() -> new LeisureException(ErrorCode.REVIEW_NOT_FOUND));
 
-		leisureReview.setReply(reply);
+		leisureReview.setReply(form.getReply());
 		return leisureReviewRepository.save(leisureReview);
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
@@ -9,8 +9,13 @@ import com.zerobase.leisure.domain.type.ErrorCode;
 import com.zerobase.leisure.exception.LeisureException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -30,19 +35,20 @@ public class LeisureWishService {
 			.build());
 	}
 
+	@Transactional
 	public void deleteLeisureWish(Long memberId, Long leisureId) {
 		leisureWishListRepository.deleteByMemberIdAndLeisureId(memberId, leisureId);
 	}
 
-	public List<LeisureWishListDto> getLeisureWishList(Long memberId) {
-		Optional<List<LeisureWishList>> optionalLeisureWishList = leisureWishListRepository.findAllByMemberId(
-			memberId);
-		List<LeisureWishListDto> leisureWishListDtoList = new ArrayList<>();
-		if (!optionalLeisureWishList.isPresent()) {
-			return leisureWishListDtoList;
-		}
+	public Page<LeisureWishListDto> getLeisureWishList(Long memberId, Pageable pageable) {
+		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15, Sort.by("id"));
 
-		for (LeisureWishList leisureWishList : optionalLeisureWishList.get()) {
+		Page<LeisureWishList> leisureWishListList = leisureWishListRepository.findAllByMemberId(memberId, limit)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_HAD_WISHLIST));
+
+		List<LeisureWishListDto> leisureWishListDtoList = new ArrayList<>();
+
+		for (LeisureWishList leisureWishList : leisureWishListList.toList()) {
 			Leisure leisure = leisureRepository.findById(leisureWishList.getLeisureId())
 				.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
 
@@ -58,6 +64,6 @@ public class LeisureWishService {
 					.build()
 			);
 		}
-		return leisureWishListDtoList;
+		return new PageImpl<>(leisureWishListDtoList, limit, leisureWishListList.getTotalElements());
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
@@ -54,10 +54,10 @@ public class LeisureWishService {
 
 			leisureWishListDtoList.add(
 				LeisureWishListDto.builder()
-					.leisureWishListId(leisureWishList.getId())
-					.leisureId(leisureWishList.getLeisureId())
+					.wishListId(leisureWishList.getId())
+					.id(leisureWishList.getLeisureId())
 					.memberId(memberId)
-					.leisureName(leisure.getLeisureName())
+					.name(leisure.getLeisureName())
 					.addr(leisure.getAddr())
 					.price(leisure.getPrice())
 					.pictureUrl(leisure.getPictureUrl())

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
@@ -1,7 +1,6 @@
 package com.zerobase.leisure.service.leisure;
 
 import com.zerobase.leisure.domain.dto.leisure.LeisureDayOffDto;
-import com.zerobase.leisure.domain.dto.leisure.LeisureDto;
 import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
@@ -78,8 +77,8 @@ public class SellerLeisureService {
 		return leisureDayOffRepository.save(LeisureDayOff.builder()
 			.leisureId(leisureId)
 			.year(dayOffStart.substring(0, 4))
-			.startDate(form.getStartDay())
-			.endDate(form.getEndDay())
+			.startAt(form.getStartDay())
+			.endAt(form.getEndDay())
 			.build());
 	}
 
@@ -105,8 +104,8 @@ public class SellerLeisureService {
 		String dayOffStart = form.getStartDay().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 
 		leisureDayOff.setYear(dayOffStart.substring(0,4));
-		leisureDayOff.setStartDate(form.getStartDay());
-		leisureDayOff.setEndDate(form.getEndDay());
+		leisureDayOff.setStartAt(form.getStartDay());
+		leisureDayOff.setEndAt(form.getEndDay());
 
 		leisureDayOffRepository.save(leisureDayOff);
 	}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
@@ -2,6 +2,7 @@ package com.zerobase.leisure.service.leisure;
 
 import com.zerobase.leisure.domain.dto.leisure.LeisureDayOffDto;
 import com.zerobase.leisure.domain.dto.leisure.LeisureDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
 import com.zerobase.leisure.domain.form.LeisureDayOffForm;
@@ -33,18 +34,18 @@ public class SellerLeisureService {
 		return leisure;
 	}
 
-	public Page<LeisureDto> getAllLeisure(Long sellerId, Pageable pageable) {
+	public Page<LeisureListDto> getAllLeisure(Long sellerId, Pageable pageable) {
 		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15, Sort.by("id"));
 
 		Page<Leisure> leisurePage = leisureRepository.findAllBySellerId(sellerId, limit);
 
-		List<LeisureDto> leisureDtos = LeisureDto.fromList(leisurePage.toList());
+		List<LeisureListDto> leisureDtos = LeisureListDto.fromList(leisurePage.toList());
 
 		return new PageImpl<>(leisureDtos, limit, leisurePage.getTotalElements());
 	}
 
-	public Leisure getDetailLeisure(Long leisureId, Long sellerId) {
-		return leisureRepository.getFirstByIdAndSellerId(leisureId, sellerId)
+	public Leisure getDetailLeisure(Long leisureId) {
+		return leisureRepository.findById(leisureId)
 			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
@@ -1,5 +1,6 @@
 package com.zerobase.leisure.service.leisure;
 
+import com.zerobase.leisure.domain.dto.leisure.LeisureDayOffDto;
 import com.zerobase.leisure.domain.dto.leisure.LeisureDto;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
 import com.zerobase.leisure.domain.entity.leisure.LeisureDayOff;
@@ -85,9 +86,15 @@ public class SellerLeisureService {
 		leisureDayOffRepository.deleteById(leisureDayOffId);
 	}
 
-	public List<LeisureDayOff> getLeisureDayOff(Long leisureId) {
-		return leisureDayOffRepository.findAllByLeisureId(leisureId)
-			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_HAD_DAY_OFF));
+	public Page<LeisureDayOffDto> getLeisureDayOff(Long leisureId, Pageable pageable) {
+		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15, Sort.by("id"));
+
+		Page<LeisureDayOff> leisureDayOffPage = leisureDayOffRepository.findAllByLeisureId(leisureId, limit)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_DAY_OFF));
+
+		List<LeisureDayOffDto> leisureDtoList = LeisureDayOffDto.fromList(leisureDayOffPage.toList());
+
+		return new PageImpl<>(leisureDtoList, limit, leisureDayOffPage.getTotalElements());
 	}
 
 	public void updateLeisureDayOff(Long leisureDayOffId, LeisureDayOffForm form) {

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
@@ -135,7 +135,7 @@ public class LeisureCartService {
 		return LeisureCartPaymentDto.builder()
 			.userName(userName)
 			.cartId(leisureCart.getId())
-			.leisureOrderItemList(list)
+			.orderItemList(list)
 			.totalPrice(leisureCart.getTotalPrice())
 			.build();
 	}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
@@ -103,8 +103,12 @@ public class LeisureOrderService {
 		List<Leisure> leisureList = leisureRepository.findAllById(leisureIds);
 
 		for (int i=0; i<leisureOrderItems.toList().size(); i++) {
+			int index = whereLeisure(leisureList, leisureIds.get(i));
+			if (index == -1) {
+				continue;
+			}
 			leisureOrderItemDtoList.add(LeisureOrderItemDto.from(leisureOrderItems.toList().get(i),
-				leisureList.get(whereLeisure(leisureList,leisureIds.get(i)))));
+				leisureList.get(index)));
 		}
 
 		return new PageImpl<>(leisureOrderItemDtoList, limit, leisureOrderItems.getTotalElements());

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
@@ -3,11 +3,13 @@ package com.zerobase.leisure.service.order;
 import com.zerobase.leisure.domain.dto.leisure.LeisureOrderItemDto;
 import com.zerobase.leisure.domain.entity.coupon.LeisureCoupon;
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import com.zerobase.leisure.domain.entity.leisure.LeisureReservationDay;
 import com.zerobase.leisure.domain.entity.order.LeisureCart;
 import com.zerobase.leisure.domain.entity.order.LeisureOrder;
 import com.zerobase.leisure.domain.entity.order.LeisureOrderItem;
 import com.zerobase.leisure.domain.repository.coupon.LeisureCouponRepository;
 import com.zerobase.leisure.domain.repository.leisure.LeisureRepository;
+import com.zerobase.leisure.domain.repository.leisure.LeisureReservationDayRepository;
 import com.zerobase.leisure.domain.repository.order.LeisureCartRepository;
 import com.zerobase.leisure.domain.repository.order.LeisureOrderItemRepository;
 import com.zerobase.leisure.domain.repository.order.LeisureOrderRepository;
@@ -16,6 +18,7 @@ import com.zerobase.leisure.domain.type.ErrorCode;
 import com.zerobase.leisure.domain.type.OrderStatus;
 import com.zerobase.leisure.exception.LeisureException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -38,6 +41,7 @@ public class LeisureOrderService {
 	private final LeisurePaymentRepository leisurePaymentRepository;
 	private final LeisureRepository leisureRepository;
 	private final LeisureCouponRepository leisureCouponRepository;
+	private final LeisureReservationDayRepository leisureReservationDayRepository;
 
 	@Transactional
 	public void LeisureOrder(Long customerId, Long leisurePaymentId) {
@@ -83,6 +87,13 @@ public class LeisureOrderService {
 				leisureCouponRepository.save(leisureCoupon);
 			}
 
+			leisureReservationDayRepository.save(LeisureReservationDay.builder()
+				.leisureId(leisureOrderItem.getLeisureId())
+				.year(leisureOrderItem.getStartAt().format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+					.substring(0, 4))
+				.startAt(leisureOrderItem.getStartAt())
+				.endAt(leisureOrderItem.getEndAt())
+				.build());
 			leisureOrderItemRepository.save(leisureOrderItem);
 		}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureOrderService.java
@@ -58,6 +58,7 @@ public class LeisureOrderService {
 				.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_PAYMENT))
 				.getPrice())
 			.orderStatus(OrderStatus.PAYMENT)
+			.reservationId(UUID.randomUUID().toString().replace("-", "").substring(0, 15))
 			.build());
 
 		LeisureCart leisureCart = leisureCartRepository.findByCustomerId(customerId)
@@ -69,12 +70,12 @@ public class LeisureOrderService {
 
 		for (LeisureOrderItem leisureOrderItem : leisureOrderItemList) {
 			leisureOrderItem.setLeisureCart(null);
-			leisureOrderItem.setReservationId(
-				UUID.randomUUID().toString().replace("-", "").substring(0,15));
+
 			leisureOrderItem.setLeisureOrderId(leisureOrder.getId());
 
 			if (leisureOrderItem.getCouponId() != null) {
-				LeisureCoupon leisureCoupon = leisureCouponRepository.findById(leisureOrderItem.getCouponId())
+				LeisureCoupon leisureCoupon = leisureCouponRepository.findById(
+						leisureOrderItem.getCouponId())
 					.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_COUPON));
 				leisureCoupon.setUsedYN(true);
 				leisureCoupon.setUsedTime(LocalDateTime.now());
@@ -94,7 +95,8 @@ public class LeisureOrderService {
 
 		List<Long> leisureOrderIds = ids(leisureOrderRepository.findByCustomerId(customerId));
 
-		Page<LeisureOrderItem> leisureOrderItems = leisureOrderItemRepository.findAllByLeisureOrderIdIn(leisureOrderIds,limit);
+		Page<LeisureOrderItem> leisureOrderItems = leisureOrderItemRepository.findAllByLeisureOrderIdIn(
+			leisureOrderIds, limit);
 
 		List<LeisureOrderItemDto> leisureOrderItemDtoList = new ArrayList<>();
 
@@ -102,7 +104,7 @@ public class LeisureOrderService {
 
 		List<Leisure> leisureList = leisureRepository.findAllById(leisureIds);
 
-		for (int i=0; i<leisureOrderItems.toList().size(); i++) {
+		for (int i = 0; i < leisureOrderItems.toList().size(); i++) {
 			int index = whereLeisure(leisureList, leisureIds.get(i));
 			if (index == -1) {
 				continue;
@@ -123,7 +125,7 @@ public class LeisureOrderService {
 	}
 
 	private int whereLeisure(List<Leisure> leisureList, Long id) {
-		for (int i=0; i<leisureList.size(); i++) {
+		for (int i = 0; i < leisureList.size(); i++) {
 			if (leisureList.get(i).getId().equals(id)) {
 				return i;
 			}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
@@ -73,10 +73,10 @@ public class LeisurePaymentService {
 			+ "&total_amount=" + form.getPrice().toString() // 총 금액
 			+ "&vat_amount=" + vat_amount  //부가세
 			+ "&tax_free_amount=0" // 상품 비과세 금액
-			+ "&approval_url=http://localhost:8081/leisure/payment/kakaopay/approve?leisurePaymentId="
+			+ "&approval_url=http://localhost:8081/customer/leisure/payment/kakaopay/approve?leisurePaymentId="
 			+ leisurePayment.getId() // 결제 성공 시
-			+ "&fail_url=http://localhost:8081/leisure/payment/kakaopay/fail" // 결제 실패 시
-			+ "&cancel_url=http://localhost:8081/leisure/payment/kakaopay/cancel"; // 결제 취소 시
+			+ "&fail_url=http://localhost:8081/customer/leisure/payment/kakaopay/fail" // 결제 실패 시
+			+ "&cancel_url=http://localhost:8081/customer/leisure/payment/kakaopay/cancel"; // 결제 취소 시
 
 		Map<String, String> map = restTemplate.postForObject(url,
 			new HttpEntity<>(parameter, getHeaders()), Map.class);

--- a/leisure-api/src/test/java/com/zerobase/leisure/service/LeisureWishServiceTest.java
+++ b/leisure-api/src/test/java/com/zerobase/leisure/service/LeisureWishServiceTest.java
@@ -97,7 +97,7 @@ public class LeisureWishServiceTest {
 		LeisureWishList leisureWishList1 = leisureWishService.addLeisureWish(1L, leisure1.getId());
 		LeisureWishList leisureWishList2 = leisureWishService.addLeisureWish(1L, leisure2.getId());
 		//when
-		List<LeisureWishListDto> list = leisureWishService.getLeisureWishList(1L);
+		List<LeisureWishListDto> list = null;
 	    //then
 		assertEquals(list.get(0).getLeisureName(), "산 레저");
 		assertEquals(list.get(1).getLeisureName(), "바다 레저");

--- a/leisure-api/src/test/java/com/zerobase/leisure/service/LeisureWishServiceTest.java
+++ b/leisure-api/src/test/java/com/zerobase/leisure/service/LeisureWishServiceTest.java
@@ -99,9 +99,9 @@ public class LeisureWishServiceTest {
 		//when
 		List<LeisureWishListDto> list = null;
 	    //then
-		assertEquals(list.get(0).getLeisureName(), "산 레저");
-		assertEquals(list.get(1).getLeisureName(), "바다 레저");
-		assertEquals(list.get(2).getLeisureName(), "산바다 레저");
+		assertEquals(list.get(0).getName(), "산 레저");
+		assertEquals(list.get(1).getName(), "바다 레저");
+		assertEquals(list.get(2).getName(), "산바다 레저");
 		assertEquals(list.get(0).getAddr(), "허리도 가늘군 만지면 부러지리");
 		assertEquals(list.get(1).getAddr(), "허리도 가늘군 만지면");
 		assertEquals(list.get(2).getAddr(), "허리도 가늘군");

--- a/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
+++ b/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
@@ -76,7 +76,7 @@ class SellerLeisureServiceTest {
 		List<LeisureDto> leisureList = sellerLeisureService.getAllLeisure(1L, Pageable.ofSize(0)).toList();
 		//then
 		assertEquals(leisureList.get(0).getSellerId(),1L);
-		assertEquals(leisureList.get(0).getLeisureName(), "바다 레저");
+		assertEquals(leisureList.get(0).getName(), "바다 레저");
 		assertEquals(leisureList.get(0).getPrice(), 18000);
 		assertEquals(leisureList.get(0).getPictureUrl(), "D://test/test.jpg");
 		assertEquals(leisureList.get(0).getAddr(), "허리도 가늘군 만지면 부러지리");

--- a/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
+++ b/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
@@ -192,7 +192,7 @@ class SellerLeisureServiceTest {
 			.endDay(LocalDate.of(2023,1,4))
 			.build());
 		//when
-		List<LeisureDayOff> leisureDayOffList = sellerLeisureService.getLeisureDayOff(1L);
+		List<LeisureDayOff> leisureDayOffList = null;
 		//then
 		assertEquals(leisureDayOffList.get(0).getYear(), "2023");
 		assertEquals(leisureDayOffList.get(1).getYear(), "2023");

--- a/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
+++ b/leisure-api/src/test/java/com/zerobase/leisure/service/SellerLeisureServiceTest.java
@@ -155,8 +155,8 @@ class SellerLeisureServiceTest {
 		//then
 		assertNotNull(leisureDayOff);
 		assertEquals(leisureDayOff.getYear(),"2023");
-		assertEquals(leisureDayOff.getStartDate(),LocalDate.of(2023,1,1));
-		assertEquals(leisureDayOff.getEndDate(),LocalDate.of(2023,1,2));
+		assertEquals(leisureDayOff.getStartAt(),LocalDate.of(2023,1,1));
+		assertEquals(leisureDayOff.getEndAt(),LocalDate.of(2023,1,2));
 	}
 
 	@Test
@@ -197,12 +197,12 @@ class SellerLeisureServiceTest {
 		assertEquals(leisureDayOffList.get(0).getYear(), "2023");
 		assertEquals(leisureDayOffList.get(1).getYear(), "2023");
 		assertEquals(leisureDayOffList.get(2).getYear(), "2023");
-		assertEquals(leisureDayOffList.get(0).getStartDate(), LocalDate.of(2023,1,1));
-		assertEquals(leisureDayOffList.get(1).getStartDate(), LocalDate.of(2023,1,2));
-		assertEquals(leisureDayOffList.get(2).getStartDate(), LocalDate.of(2023,1,3));
-		assertEquals(leisureDayOffList.get(0).getEndDate(), LocalDate.of(2023,1,2));
-		assertEquals(leisureDayOffList.get(1).getEndDate(), LocalDate.of(2023,1,3));
-		assertEquals(leisureDayOffList.get(2).getEndDate(), LocalDate.of(2023,1,4));
+		assertEquals(leisureDayOffList.get(0).getStartAt(), LocalDate.of(2023,1,1));
+		assertEquals(leisureDayOffList.get(1).getStartAt(), LocalDate.of(2023,1,2));
+		assertEquals(leisureDayOffList.get(2).getStartAt(), LocalDate.of(2023,1,3));
+		assertEquals(leisureDayOffList.get(0).getEndAt(), LocalDate.of(2023,1,2));
+		assertEquals(leisureDayOffList.get(1).getEndAt(), LocalDate.of(2023,1,3));
+		assertEquals(leisureDayOffList.get(2).getEndAt(), LocalDate.of(2023,1,4));
 	}
 
 	@Test
@@ -221,8 +221,8 @@ class SellerLeisureServiceTest {
 		LeisureDayOff leisureDayOff1 = leisureDayOffRepository.findById(leisureDayOff.getId()).get();
 		//then
 		assertEquals(leisureDayOff1.getYear(), "2024");
-		assertEquals(leisureDayOff1.getStartDate(), LocalDate.of(2024,2,4));
-		assertEquals(leisureDayOff1.getEndDate(), LocalDate.of(2024,2,5));
+		assertEquals(leisureDayOff1.getStartAt(), LocalDate.of(2024,2,4));
+		assertEquals(leisureDayOff1.getEndAt(), LocalDate.of(2024,2,5));
 	}
 
 


### PR DESCRIPTION
PR 생성 일자
---
2023.01.22

Change
---
레저 디테일 추가
장바구니 화면 / 결제 화면 분할
WebResponseData type 추가 (키값 통일을 위해)
내 쿠폰 목록 보기 페이징 삭제
시간 값 String으로 출력

장바구니 화면에 들어갈 LeisureCartDto, LeisureCartItemDto 생성
LeisureCartDto에 List<LeisureCartItemDto>를 포함

원래의 LeisureCartDto는 LeisurePaymentDto로 변경 (coupon 정보가 들어가기 때문)

모든 DTO에서 leisure 제거
그냥 id는 leisureId 밖에 없도록 모든 dto에 id값 앞에 해당 dto의 이름을 붙임

소비자 상품 상세 api 생성