### PR TITLE
[다륜] 쿠폰 리스트 페이징 제거

### DIFF
--- a/leisure-api/src/main/java/com/zerobase/leisure/config/SimpleCorsFilter.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/config/SimpleCorsFilter.java
@@ -1,0 +1,35 @@
+package com.zerobase.leisure.config;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SimpleCorsFilter implements Filter {
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
+		HttpServletRequest request = (HttpServletRequest) req;
+		HttpServletResponse response = (HttpServletResponse) res;
+		response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
+		response.setHeader("Access-Control-Allow-Credentials", "true");
+		response.setHeader("Access-Control-Allow-Methods", "POST, GET, OPTIONS, DELETE, PUT, PATCH");
+		response.setHeader("Access-Control-Max-Age", "3600");
+		response.setHeader("Access-Control-Allow-Headers", "Content-Type, Accept, X-Requested-With, remember-me");
+		chain.doFilter(req, res);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) {
+	}
+
+	@Override
+	public void destroy() {
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/order/LeisureOrderController.java
@@ -1,6 +1,7 @@
 package com.zerobase.leisure.controller.order;
 
-import com.zerobase.leisure.domain.dto.leisure.LeisureOrderItemDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureOrderCompleteDto;
+import com.zerobase.leisure.domain.dto.leisure.LeisureOrderDto;
 import com.zerobase.leisure.domain.dto.leisure.LeisureOrderListDto;
 import com.zerobase.leisure.domain.model.WebResponseData;
 import com.zerobase.leisure.service.order.LeisureOrderService;
@@ -21,12 +22,12 @@ public class LeisureOrderController {
 
 	private final LeisureOrderService leisureOrderService;
 	@PostMapping
-	public @ResponseBody WebResponseData<String> LeisureOrder(@RequestParam Long leisurePaymentId, Long customerId) {
+	public @ResponseBody WebResponseData<LeisureOrderCompleteDto> LeisureOrder(@RequestParam Long leisurePaymentId, Long customerId) {
 //		if (memberDetails==null) {
 //			throw new LeisureException(ErrorCode.NOT_AUTHORIZED);
 //		}
-		leisureOrderService.LeisureOrder(customerId, leisurePaymentId);
-		return WebResponseData.ok("예약에 성공하였습니다.");
+
+		return WebResponseData.ok(leisureOrderService.LeisureOrder(customerId, leisurePaymentId));
 	}
 
 	@GetMapping
@@ -39,11 +40,10 @@ public class LeisureOrderController {
 	}
 
 	@GetMapping("/detail")
-	public @ResponseBody WebResponseData<Page<LeisureOrderItemDto>> getLeisureOrderDetail(@RequestParam Long orderId,
-		final Pageable pageable) {
+	public @ResponseBody WebResponseData<LeisureOrderDto> getLeisureOrderDetail(@RequestParam Long orderId) {
 //		if (memberDetails==null) {
 //			throw new LeisureException(ErrorCode.NOT_AUTHORIZED);
 //		}
-		return WebResponseData.ok(leisureOrderService.getLeisureOrderDetail(orderId,pageable));
+		return WebResponseData.ok(leisureOrderService.getLeisureOrderDetail(orderId));
 	}
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/controller/search/SearchLeisureController.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/controller/search/SearchLeisureController.java
@@ -1,0 +1,41 @@
+package com.zerobase.leisure.controller.search;
+
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
+import com.zerobase.leisure.domain.form.SearchLeisureForm;
+import com.zerobase.leisure.domain.model.WebResponseData;
+import com.zerobase.leisure.service.search.SearchLeisureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/leisure/search")
+@RequiredArgsConstructor
+public class SearchLeisureController {
+
+	private final SearchLeisureService searchLeisureService;
+
+	@PostMapping
+	public WebResponseData<Page<LeisureListDto>> getAllSearchResult(@RequestBody SearchLeisureForm form, final Pageable pageable) {
+		Page<LeisureListDto> leisureListDtoPage = searchLeisureService.getAllSearchResult(form, pageable);
+		return WebResponseData.ok(leisureListDtoPage);
+	}
+
+	@GetMapping("/addr")
+	public WebResponseData<Page<LeisureListDto>> getAllSearchAddr(@RequestParam String addr, final Pageable pageable) {
+		Page<LeisureListDto> leisureListDtoPage = searchLeisureService.getAllSearchAddr(addr, pageable);
+		return WebResponseData.ok(leisureListDtoPage);
+	}
+
+	@GetMapping("/category")
+	public WebResponseData<Page<LeisureListDto>> getAllSearchCategory(@RequestParam String category, final Pageable pageable) {
+		Page<LeisureListDto> leisureListDtoPage = searchLeisureService.getAllSearchCategory(category, pageable);
+		return WebResponseData.ok(leisureListDtoPage);
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureCartDto.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 public class LeisureCartDto {
 	private Long cartId;
 
-	private List<LeisureCartItemDto> cartItemList;
+	private List<LeisureCartItemDto> orderItemList;
 
 	private Integer totalPrice;
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderCompleteDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderCompleteDto.java
@@ -1,0 +1,15 @@
+package com.zerobase.leisure.domain.dto.leisure;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeisureOrderCompleteDto {
+	private String reservationId;
+	private Integer price;
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderDto.java
@@ -1,0 +1,37 @@
+package com.zerobase.leisure.domain.dto.leisure;
+
+import com.zerobase.leisure.domain.entity.order.LeisureOrder;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeisureOrderDto {
+	private Long orderId;
+
+	private String reservationAt;
+
+	private String reservationId;
+
+	private String customerName;
+
+	private String email;
+
+	private List<LeisureOrderItemListDto> orderItemList;
+
+	public static LeisureOrderDto from(LeisureOrder leisureOrder, List<LeisureOrderItemListDto> leisureOrderItemDtoList) {
+		return LeisureOrderDto.builder()
+			.reservationAt(leisureOrder.getCreateAt().toString())
+			.orderId(leisureOrder.getId())
+			.reservationId(leisureOrder.getReservationId())
+			.customerName("String")
+			.email("String")
+			.orderItemList(leisureOrderItemDtoList)
+			.build();
+	}
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemListDto.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/dto/leisure/LeisureOrderItemListDto.java
@@ -1,7 +1,6 @@
 package com.zerobase.leisure.domain.dto.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
-import com.zerobase.leisure.domain.entity.order.LeisureOrder;
 import com.zerobase.leisure.domain.entity.order.LeisureOrderItem;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,11 +11,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class LeisureOrderListDto {
-	private Long orderId;
-	private String reservationAt;
-
-	private String reservationId;
+public class LeisureOrderItemListDto {
+	private Long orderItemId;
+	private Long sellerId;
 
 	private String name;
 
@@ -24,21 +21,16 @@ public class LeisureOrderListDto {
 
 	private Integer persons;
 
-	private Integer orderCount; //주문 개수
-
 	private String startAt;
 	private String endAt;
 
-	public static LeisureOrderListDto from(LeisureOrder leisureOrder, LeisureOrderItem leisureOrderItem, Leisure leisure
-		,int cnt) {
-		return LeisureOrderListDto.builder()
-			.reservationAt(leisureOrder.getCreateAt().toString())
-			.orderId(leisureOrder.getId())
-			.reservationId(leisureOrder.getReservationId())
-			.name(leisure.getLeisureName())
+	public static LeisureOrderItemListDto from(LeisureOrderItem leisureOrderItem, Leisure leisure) {
+		return LeisureOrderItemListDto.builder()
+			.orderItemId(leisureOrderItem.getId())
+			.sellerId(leisure.getSellerId())
 			.pictureUrl(leisure.getPictureUrl())
+			.name(leisure.getLeisureName())
 			.persons(leisureOrderItem.getPersons())
-			.orderCount(cnt)
 			.startAt(leisureOrderItem.getStartAt().toString())
 			.endAt(leisureOrderItem.getEndAt().toString())
 			.build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/Leisure.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/Leisure.java
@@ -2,6 +2,7 @@ package com.zerobase.leisure.domain.entity.leisure;
 
 import com.zerobase.leisure.domain.entity.common.BaseEntity;
 import com.zerobase.leisure.domain.form.LeisureForm;
+import com.zerobase.leisure.domain.type.Category;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -27,6 +28,8 @@ public class Leisure extends BaseEntity {
 	private Long id;
 
 	private Long sellerId;
+
+	private Category category;
 
 	private String leisureName;
 	private String addr;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/Leisure.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/Leisure.java
@@ -47,7 +47,7 @@ public class Leisure extends BaseEntity {
 	public static Leisure of(Long sellerId, LeisureForm form) {
 		return Leisure.builder()
 			.sellerId(sellerId)
-			.leisureName(form.getLeisureName())
+			.leisureName(form.getName())
 			.addr(form.getAddr())
 			.price(form.getPrice())
 			.description(form.getDescription())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/LeisureReview.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/leisure/LeisureReview.java
@@ -39,7 +39,7 @@ public class LeisureReview extends BaseEntity {
 		return LeisureReview.builder()
 			.customerId(form.getCustomerId())
 			.sellerId(form.getSellerId())
-			.leisureId(form.getLeisureId())
+			.leisureId(form.getProductId())
 			.rating(form.getRating())
 			.description(form.getDescription())
 			.reply(form.getReply())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrderItem.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/entity/order/LeisureOrderItem.java
@@ -50,7 +50,7 @@ public class LeisureOrderItem extends BaseEntity {
 	public static LeisureOrderItem of(Long sellerId, Integer price, LeisureCart leisureCart, AddLeisureCartForm form) {
 		return LeisureOrderItem.builder()
 			.sellerId(sellerId)
-			.leisureId(form.getLeisureId())
+			.leisureId(form.getProductId())
 			.leisureCart(leisureCart)
 			.persons(form.getPersons())
 			.startAt(form.getStartAt())

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureBlackListForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureBlackListForm.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AddLeisureBlackListForm {
 
-    private Long leisureId;
+    private Long productId;
 
     private Long customerId;
     private String description;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCartForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCartForm.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 public class AddLeisureCartForm {
-	private Long leisureId;
+	private Long productId;
 	private Integer persons;
 	private LocalDateTime startAt;
 	private LocalDateTime endAt;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCouponGroupForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureCouponGroupForm.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 public class AddLeisureCouponGroupForm {
-    private Long leisureCouponGroupId;
+    private Long couponGroupId;
 
     private Integer salePrice;
     private CouponTarget couponTarget;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureReviewForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/AddLeisureReviewForm.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 public class AddLeisureReviewForm {
 	private Long customerId;
 	private Long sellerId;
-	private Long leisureId;
+	private Long productId;
 
 	private double rating;
 	private String description;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/LeisureForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/LeisureForm.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LeisureForm {
-	private String leisureName;
+	private String name;
 	private String addr;
 	private Integer price;
 	private String pictureUrl;

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/SearchLeisureForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/SearchLeisureForm.java
@@ -1,0 +1,12 @@
+package com.zerobase.leisure.domain.form;
+
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+public class SearchLeisureForm {
+	private String addr;
+	private Integer personnel;
+	private LocalDate startAt;
+	private LocalDate endAt;
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/form/payment/LeisurePaymentForm.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/form/payment/LeisurePaymentForm.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 
 @Getter
 public class LeisurePaymentForm {
-    private Long leisureOrderItemId; // 주문 상품 아이디
+    private Long orderItemId; // 주문 상품 아이디
 
-    private Long leisureId;
+    private Long productId;
 
     private Integer price;
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureRepository.java
@@ -15,9 +15,9 @@ public interface LeisureRepository extends JpaRepository<Leisure, Long> {
 	Page<Leisure> findAllBySellerId(Long sellerId, Pageable limit);
 	Optional<Leisure> getFirstByIdAndSellerId(Long id, Long sellerId);
 
-	@Query(nativeQuery = true, value = "SELECT * From accommodation as a"
-		+ " Where a.addr Like :p_addr AND a.min_person <= :per1 AND a.max_person >= :per2 AND a.id NOT IN (:p_ids)")
-	Optional<Leisure> findAllByAddr(@Param("p_addr") String addr,@Param("per1")Integer personnel,@Param("per2") Integer personnel2,@Param("p_ids")List<Long> accommodationIds);
+	@Query(nativeQuery = true, value = "SELECT * From leisure as a"
+		+ " Where a.addr Like :addr AND a.min_person <= :personnel AND a.max_person >= :personnel2 AND a.id NOT IN (:leisureIds)")
+	Optional<Leisure> findAllByAddr(@Param("addr")String addr, @Param("personnel")Integer personnel, @Param("personnel2") Integer personnel2, @Param("leisureIds")List<Long> leisureIds);
 
 	List<Leisure> findAllByAddrLikeAndMinPersonLessThanEqualAndMaxPersonGreaterThanEqual(String addr, Integer personnel, Integer personnel2);
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureRepository.java
@@ -1,15 +1,27 @@
 package com.zerobase.leisure.domain.repository.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LeisureRepository extends JpaRepository<Leisure, Long> {
 	Page<Leisure> findAllBySellerId(Long sellerId, Pageable limit);
 	Optional<Leisure> getFirstByIdAndSellerId(Long id, Long sellerId);
+
+	@Query(nativeQuery = true, value = "SELECT * From accommodation as a"
+		+ " Where a.addr Like :p_addr AND a.min_person <= :per1 AND a.max_person >= :per2 AND a.id NOT IN (:p_ids)")
+	Optional<Leisure> findAllByAddr(@Param("p_addr") String addr,@Param("per1")Integer personnel,@Param("per2") Integer personnel2,@Param("p_ids")List<Long> accommodationIds);
+
+	List<Leisure> findAllByAddrLikeAndMinPersonLessThanEqualAndMaxPersonGreaterThanEqual(String addr, Integer personnel, Integer personnel2);
+
+	Optional<Page<Leisure>> findAllByAddrContaining(String s_addr, Pageable limit);
+
+	Optional<Page<Leisure>> findAllByCategoryContaining(String category, Pageable limit);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
@@ -1,7 +1,10 @@
 package com.zerobase.leisure.domain.repository.leisure;
 
 import com.zerobase.leisure.domain.entity.leisure.LeisureReservationDay;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +13,6 @@ import org.springframework.stereotype.Repository;
 public interface LeisureReservationDayRepository extends JpaRepository<LeisureReservationDay, Long> {
 	Optional<LeisureReservationDay> findByLeisureIdAndStartAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
 	Optional<LeisureReservationDay> findByLeisureIdAndEndAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
+
+	List<Long> findAllLeisureId(@Param("p_startAt") LocalDate startAt,@Param("p_endAt") LocalDate endAt);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureReservationDayRepository.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,5 +15,7 @@ public interface LeisureReservationDayRepository extends JpaRepository<LeisureRe
 	Optional<LeisureReservationDay> findByLeisureIdAndStartAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
 	Optional<LeisureReservationDay> findByLeisureIdAndEndAtBetween(Long leisureId, LocalDateTime startAt, LocalDateTime endAt);
 
-	List<Long> findAllLeisureId(@Param("p_startAt") LocalDate startAt,@Param("p_endAt") LocalDate endAt);
+	@Query("SELECT distinct leisureId From LeisureReservationDay "
+		+ "Where startAt between :startAt and :endAt or endAt between :startAt and :endAt")
+	List<Long> findAllLeisureId(@Param("startAt") LocalDate startAt,@Param("endAt") LocalDate endAt);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureWishListRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/leisure/LeisureWishListRepository.java
@@ -15,4 +15,6 @@ public interface LeisureWishListRepository extends JpaRepository<LeisureWishList
 	void deleteByMemberIdAndLeisureId(Long memberId, Long leisureId);
 
 	Optional<Page<LeisureWishList>> findAllByMemberId(Long memberId, Pageable limit);
+
+	Optional<LeisureWishList> findByMemberIdAndLeisureId(Long memberId, Long leisureId);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderItemRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderItemRepository.java
@@ -18,7 +18,7 @@ public interface LeisureOrderItemRepository extends JpaRepository<LeisureOrderIt
 	Optional<List<LeisureOrderItem>> findByLeisureOrderId(Long orderId);
 
 	Page<LeisureOrderItem> findAllByLeisureOrderIdIn(List<Long> ids, Pageable limit);
-	Page<LeisureOrderItem> findAllByLeisureOrderId(Long orderId, Pageable limit);
+	List<LeisureOrderItem> findAllByLeisureOrderId(Long orderId);
 
 	Optional<LeisureOrderItem> findByCouponId(Long couponId);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderRepository.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/repository/order/LeisureOrderRepository.java
@@ -13,4 +13,6 @@ public interface LeisureOrderRepository extends JpaRepository<LeisureOrder, Long
 	Optional<LeisureOrder> findByCustomerIdAndLeisurePaymentId(Long customerId, Long leisurePaymentId);
 
 	Page<LeisureOrder> findByCustomerId(Long customerId, Pageable limit);
+
+	Optional<LeisureOrder> findByLeisurePaymentId(Long leisurePaymentId);
 }

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/type/Category.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/type/Category.java
@@ -1,0 +1,8 @@
+package com.zerobase.leisure.domain.type;
+
+public enum Category {
+	MOUNTAIN,
+	SEA,
+	VALLEY,
+	HOTEL;
+}

--- a/leisure-api/src/main/java/com/zerobase/leisure/domain/type/ErrorCode.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/domain/type/ErrorCode.java
@@ -36,7 +36,10 @@ public enum ErrorCode {
 	NOT_MY_COUPON("발급 받은 쿠폰이 아닙니다."),
 	NOT_FOUND_COUPON("쿠폰 정보를 찾을 수 없습니다."),
 	ALREADY_USED_COUPON("이미 사용한 쿠폰입니다."),
-	ALREADY_RESERVATION_DAY("이미 예약된 시간입니다.")
+	ALREADY_RESERVATION_DAY("이미 예약된 시간입니다."),
+	NOT_FOUND_ORDER("주문 정보를 찾을 수 없습니다."),
+	ALREADY_WISHED_LEISURE("이미 찜한 상품입니다"),
+	NOT_WISHED_LEISURE("찜한 상품이 아닙니다.")
 	;
 
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/coupon/LeisureCouponGroupService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/coupon/LeisureCouponGroupService.java
@@ -28,7 +28,7 @@ public class LeisureCouponGroupService {
     }
 
     public LeisureCouponGroup updateLeisureCouponGroup(AddLeisureCouponGroupForm form) {
-        LeisureCouponGroup leisureCouponGroup = findCouponGroup(form.getLeisureCouponGroupId());
+        LeisureCouponGroup leisureCouponGroup = findCouponGroup(form.getCouponGroupId());
 
         leisureCouponGroup.setCouponTarget(form.getCouponTarget());
         leisureCouponGroup.setSalePrice(form.getSalePrice());

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureBlackListService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureBlackListService.java
@@ -29,13 +29,13 @@ public class LeisureBlackListService {
     public LeisureBlackList addLeisureBlackList(AddLeisureBlackListForm form) {
         Optional<LeisureBlackList> leisureBlackListOptional =
             leisureBlackListRepository.findByCustomerIdAndLeisureId(form.getCustomerId(),
-                form.getLeisureId());
+                form.getProductId());
         if (leisureBlackListOptional.isPresent()) {
             throw new LeisureException(ErrorCode.ALREADY_DENIED_USER);
         }
 
         LeisureBlackList leisureBlackList = LeisureBlackList.builder()
-            .leisureId(form.getLeisureId())
+            .leisureId(form.getProductId())
             .customerId(form.getCustomerId())
             .description(form.getDescription())
             .build();

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/LeisureWishService.java
@@ -29,6 +29,11 @@ public class LeisureWishService {
 		leisureRepository.findById(leisureId)
 			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
 
+		if (leisureWishListRepository.findByMemberIdAndLeisureId(memberId, leisureId)
+			.isPresent()) {
+			throw new LeisureException(ErrorCode.ALREADY_WISHED_LEISURE);
+		}
+
 		return leisureWishListRepository.save(LeisureWishList.builder()
 			.memberId(memberId)
 			.leisureId(leisureId)
@@ -37,7 +42,8 @@ public class LeisureWishService {
 
 	@Transactional
 	public void deleteLeisureWish(Long memberId, Long leisureId) {
-		leisureWishListRepository.deleteByMemberIdAndLeisureId(memberId, leisureId);
+		leisureWishListRepository.delete(leisureWishListRepository.findByMemberIdAndLeisureId(memberId, leisureId)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_WISHED_LEISURE)));
 	}
 
 	public Page<LeisureWishListDto> getLeisureWishList(Long memberId, Pageable pageable) {

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/leisure/SellerLeisureService.java
@@ -52,7 +52,7 @@ public class SellerLeisureService {
 		Leisure leisure = leisureRepository.findById(leisureId)
 			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
 
-		leisure.setLeisureName(form.getLeisureName());
+		leisure.setLeisureName(form.getName());
 		leisure.setAddr(form.getAddr());
 		leisure.setDescription(form.getDescription());
 		leisure.setPrice(form.getPrice());

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
@@ -197,6 +197,11 @@ public class LeisureCartService {
 		leisureOrderItem.setPrice(leisureOrderItem.getPrice()+leisureOrderItem.getSalePrice());
 		leisureOrderItem.setSalePrice(0);
 
+		LeisureCoupon leisureCoupon = leisureCouponRepository.findById(leisureOrderItem.getCouponId()).get();
+		leisureCoupon.setUsedYN(false);
+
+		leisureCouponRepository.save(leisureCoupon);
+
 		leisureOrderItemRepository.save(leisureOrderItem);
 	}
 

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/order/LeisureCartService.java
@@ -41,10 +41,10 @@ public class LeisureCartService {
 
 	public void addLeisureCart(Long customerId, AddLeisureCartForm form) {
 		if (leisureOrderItemRepository.findByLeisureCart_CustomerIdAndLeisureId(customerId,
-			form.getLeisureId()).isPresent()) {
+			form.getProductId()).isPresent()) {
 			throw new LeisureException(ErrorCode.ALREADY_IN_CART);
 		}
-		Leisure leisure = leisureRepository.findById(form.getLeisureId())
+		Leisure leisure = leisureRepository.findById(form.getProductId())
 			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
 
 		if (leisure.getMinPerson() > form.getPersons()
@@ -54,9 +54,9 @@ public class LeisureCartService {
 		Optional<LeisureCart> optionalLeisureCart = leisureCartRepository.findByCustomerId(
 			customerId);
 
-		if (leisureReservationDayRepository.findByLeisureIdAndStartAtBetween(form.getLeisureId(), form.getStartAt(),form.getEndAt())
+		if (leisureReservationDayRepository.findByLeisureIdAndStartAtBetween(form.getProductId(), form.getStartAt(),form.getEndAt())
 			.isPresent()) throw new LeisureException(ErrorCode.ALREADY_RESERVATION_DAY);
-		if (leisureReservationDayRepository.findByLeisureIdAndEndAtBetween(form.getLeisureId(), form.getStartAt(),form.getEndAt())
+		if (leisureReservationDayRepository.findByLeisureIdAndEndAtBetween(form.getProductId(), form.getStartAt(),form.getEndAt())
 			.isPresent()) throw new LeisureException(ErrorCode.ALREADY_RESERVATION_DAY);
 
 		LeisureCart leisureCart= optionalLeisureCart.orElseGet(
@@ -117,7 +117,7 @@ public class LeisureCartService {
 
 		return LeisureCartDto.builder()
 			.cartId(leisureCart.getId())
-			.cartItemList(list)
+			.orderItemList(list)
 			.totalPrice(totalPrice)
 			.build();
 	}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
@@ -62,8 +62,8 @@ public class LeisurePaymentService {
 		LeisurePayment leisurePayment = LeisurePayment.builder()
 			.price(form.getPrice())
 			.customerId(customerId)
-			.leisureOrderItemId(form.getLeisureOrderItemId())
-			.leisureId(form.getLeisureId())
+			.leisureOrderItemId(form.getOrderItemId())
+			.leisureId(form.getProductId())
 			.status(PaymentStatus.PAYMENT_WAIT)
 			.build();
 
@@ -72,7 +72,7 @@ public class LeisurePaymentService {
 		int vat_amount = form.getPrice() / 10;
 
 		String parameter = "cid=TC0ONETIME" // 가맹점 코드 - 테스트용으로 고정
-			+ "&partner_order_id=" + form.getLeisureOrderItemId()// 가맹점 주문번호를 상품주문 ID로 사용
+			+ "&partner_order_id=" + form.getOrderItemId()// 가맹점 주문번호를 상품주문 ID로 사용
 			+ "&partner_user_id=" + customerId // 가맹점 회원 id
 			+ "&item_name=상품명" //leisureRepository.findById(leisureOrderItem.getLeisureId())
 			//.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE)).getLeisureName()// 상품명

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/payment/LeisurePaymentService.java
@@ -1,10 +1,15 @@
 package com.zerobase.leisure.service.payment;
 
 import com.zerobase.leisure.domain.dto.payment.LeisurePaymentDto;
+import com.zerobase.leisure.domain.entity.order.LeisureCart;
+import com.zerobase.leisure.domain.entity.order.LeisureOrder;
 import com.zerobase.leisure.domain.entity.order.LeisurePayment;
 import com.zerobase.leisure.domain.form.payment.LeisurePaymentForm;
+import com.zerobase.leisure.domain.repository.order.LeisureCartRepository;
+import com.zerobase.leisure.domain.repository.order.LeisureOrderRepository;
 import com.zerobase.leisure.domain.repository.order.LeisurePaymentRepository;
 import com.zerobase.leisure.domain.type.ErrorCode;
+import com.zerobase.leisure.domain.type.OrderStatus;
 import com.zerobase.leisure.domain.type.PaymentStatus;
 import com.zerobase.leisure.exception.LeisureException;
 import java.util.ArrayList;
@@ -31,6 +36,8 @@ import org.springframework.web.client.RestTemplate;
 public class LeisurePaymentService {
 
 	private final LeisurePaymentRepository leisurePaymentRepository;
+	private final LeisureCartRepository leisureCartRepository;
+	private final LeisureOrderRepository leisureOrderRepository;
 
 	private static final String AUTHORIZATION = "KakaoAK 5d569ea19c6b8b53c9342d4d65a394e6"; //카카오페이 api 키
 	private static final String CONTENTTYPE = "application/x-www-form-urlencoded;charset=utf-8";
@@ -49,9 +56,9 @@ public class LeisurePaymentService {
 		RestTemplate restTemplate = new RestTemplate();
 		String url = "https://kapi.kakao.com/v1/payment/ready"; //카카오 APi URL
 
-		//상품 주문에서 상품 주문관련 데이터 가져오기
-//        LeisureOrderItem leisureOrderItem = leisureOrderItemRepository.findById(form.getLeisureOrderItemId())
-//            .orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_ORDER_ITEM));
+		LeisureCart leisureCart = leisureCartRepository.findByCustomerId(customerId)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_CART));
+
 		LeisurePayment leisurePayment = LeisurePayment.builder()
 			.price(form.getPrice())
 			.customerId(customerId)
@@ -134,6 +141,12 @@ public class LeisurePaymentService {
 		log.info(map.toString());
 
 		leisurePayment.setStatus(PaymentStatus.CANCELED);
+
+		LeisureOrder leisureOrder = leisureOrderRepository.findByLeisurePaymentId(leisurePaymentId)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_ORDER));
+
+		leisureOrder.setOrderStatus(OrderStatus.CANCEL);
+		leisureOrderRepository.save(leisureOrder);
 
 		return leisurePaymentRepository.save(leisurePayment);
 	}

--- a/leisure-api/src/main/java/com/zerobase/leisure/service/search/SearchLeisureService.java
+++ b/leisure-api/src/main/java/com/zerobase/leisure/service/search/SearchLeisureService.java
@@ -1,0 +1,92 @@
+package com.zerobase.leisure.service.search;
+
+import com.zerobase.leisure.domain.dto.leisure.LeisureListDto;
+import com.zerobase.leisure.domain.entity.leisure.Leisure;
+import com.zerobase.leisure.domain.form.SearchLeisureForm;
+import com.zerobase.leisure.domain.repository.leisure.LeisureRepository;
+import com.zerobase.leisure.domain.repository.leisure.LeisureReservationDayRepository;
+import com.zerobase.leisure.domain.type.ErrorCode;
+import com.zerobase.leisure.exception.LeisureException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchLeisureService {
+
+	private final LeisureReservationDayRepository leisureReservationDayRepository;
+	private final LeisureRepository leisureRepository;
+
+	public Page<LeisureListDto> getAllSearchResult(SearchLeisureForm form, Pageable pageable) {
+		PageRequest pageRequest = PageRequest.of(pageable.getPageNumber(), 15);
+
+		//예약일 정보가 있는 id들만 가져오기
+		List<Long> leisureIds
+			= leisureReservationDayRepository.findAllLeisureId(form.getStartAt(),
+			form.getEndAt());
+		List<Leisure> list;
+
+		String adrr = "%"+form.getAddr()+"%";
+
+		if (leisureIds.size() > 0) {
+			list = new ArrayList<>();
+			//예약일 정보가 없고, 주소 값에 들어가는 숙박 정보들만 가져오기
+			list.add(
+				leisureRepository.findAllByAddr(
+					adrr, form.getPersonnel(), form.getPersonnel(), leisureIds).orElseThrow(
+					() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE)));
+
+		} else {
+			list = leisureRepository.findAllByAddrLikeAndMinPersonLessThanEqualAndMaxPersonGreaterThanEqual(
+				adrr, form.getPersonnel(),
+				form.getPersonnel());
+		}
+
+		List<LeisureListDto> dtoList = new ArrayList<>();
+
+		for (Leisure leisure : list) {
+			dtoList.add(LeisureListDto.from(leisure));
+		}
+
+		int start = (int) pageRequest.getOffset();
+		int end = Math.min((start + pageRequest.getPageSize()), dtoList.size());
+
+		return new PageImpl<>(dtoList.subList(start, end), pageRequest, dtoList.size());
+	}
+
+	public Page<LeisureListDto> getAllSearchAddr(String addr, Pageable pageable) {
+		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15);
+
+		String s_addr = "%"+addr+"%";
+
+		Page<Leisure> accommodationList = leisureRepository.findAllByAddrContaining(addr, limit)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
+
+		List<LeisureListDto> dtoList = new ArrayList<>();
+
+		for (Leisure leisure : accommodationList) {
+			dtoList.add(LeisureListDto.from(leisure));
+		}
+		return new PageImpl<>(dtoList, limit, accommodationList.getTotalElements());
+	}
+
+	public Page<LeisureListDto> getAllSearchCategory(String category, Pageable pageable) {
+		Pageable limit = PageRequest.of(pageable.getPageNumber(), 15);
+
+		Page<Leisure> accommodationList = leisureRepository.findAllByCategoryContaining(category, limit)
+			.orElseThrow(() -> new LeisureException(ErrorCode.NOT_FOUND_LEISURE));
+
+		List<LeisureListDto> dtoList = new ArrayList<>();
+
+		for (Leisure leisure : accommodationList) {
+			dtoList.add(LeisureListDto.from(leisure));
+		}
+		return new PageImpl<>(dtoList, limit, accommodationList.getTotalElements());
+	}
+}


### PR DESCRIPTION
PR 생성 일자
---
2023.01.23

Change
---
- 쿠폰 적용 취소 로직 수정
- 주문 api 호출 후 내려줄 LeisureOrderCompleteDto 생성
- 주문 api 호출 후 LeisureOrderCompleteDto 내리게 수정
- 주문 내역 상세보기 api 에서 LeisureOrderDto를 내리도록 수정
- coupon 정보가 없는 LeisureOrderItemListDto 생성
- LeisureOrderDto에 List<LeisureOrderItemListDto>를 포함 주문 get 메소드의 모든 리턴값에 주문 일자 추가
- 찜목록 등록/삭제 시 예외처리 추가